### PR TITLE
Avoid starting a headless Win10

### DIFF
--- a/ModernIE.vagrantfile
+++ b/ModernIE.vagrantfile
@@ -22,6 +22,7 @@ Vagrant.configure("2") do |config|
   config.vm.box = "modernIE/w10-edge"
 
   config.vm.provider "virtualbox" do |vb|
+    vb.gui = true
     vb.customize ["modifyvm", :id, "--memory", "1024"]
     vb.customize ["modifyvm", :id, "--vram", "128"]
     vb.customize ["modifyvm", :id,  "--cpus", "2"]


### PR DESCRIPTION
In order to use Edge it is preferable to have the UI by default
https://docs.vagrantup.com/v2/virtualbox/configuration.html